### PR TITLE
Add argument 'many' to AttrField and TextField, and changed their API

### DIFF
--- a/docs/cn/topics/item.md
+++ b/docs/cn/topics/item.md
@@ -40,19 +40,20 @@ for item in items:
 我们可以使用`Field`字段的`many=True`参数，使这个字段返回一个列表。
 
 ```python
-from ruia import Item, TextField
+import asyncio
+from ruia import Item, TextField, AttrField
+
 
 class GithiubIssueItem(Item):
-    issue_id = TextField(css_select='issue_id_class')
-    title = TextField(css_select='issue_title_class')
-    tags = TextField(css_select='tag_class',many=True)
-    
-    
-item = GithiubIssueItem.get_item(html)
+    title = TextField(css_select='title')
+    tags = AttrField(css_select='a.IssueLabel', attr='data-name', many=True)
+
+
+item = asyncio.run(GithiubIssueItem.get_item(url='https://github.com/pypa/pip/issues/72'))
 assert isinstance(item.tags, list)
 ```
 
-同样，`AttrField`也支持`many`参数。
+同样，`TextField`也支持`many`参数。
 
 ### How It Works?
 最终`Item`类会将输入最终转化为`etree._Element`对象进行处理，然后利用元类的思想将每一个`Field`构造的属性计算为源网页上对应的真实数据

--- a/docs/cn/topics/item.md
+++ b/docs/cn/topics/item.md
@@ -35,5 +35,24 @@ for item in items:
 
 ```
 
+有时你会遇见这样一种情况，例如爬取Github的Issue时，你会发现一个Issue可能对应多个Tag。
+这时，将Tag作为一个独立的`Item`来提取是不划算的，
+我们可以使用`Field`字段的`many=True`参数，使这个字段返回一个列表。
+
+```python
+from ruia import Item, TextField
+
+class GithiubIssueItem(Item):
+    issue_id = TextField(css_select='issue_id_class')
+    title = TextField(css_select='issue_title_class')
+    tags = TextField(css_select='tag_class',many=True)
+    
+    
+item = GithiubIssueItem.get_item(html)
+assert isinstance(item.tags, list)
+```
+
+同样，`AttrField`也支持`many`参数。
+
 ### How It Works?
 最终`Item`类会将输入最终转化为`etree._Element`对象进行处理，然后利用元类的思想将每一个`Field`构造的属性计算为源网页上对应的真实数据

--- a/docs/cn/topics/selector.md
+++ b/docs/cn/topics/selector.md
@@ -6,16 +6,18 @@
 
 ### Core arguments
 
+所有的`Field`共有的参数：
+- default: str, 设置默认值
+- many: bool, 返回值将是一个列表
+
 对于`AttrField`，主要参数说明如下：
-- css_select：利用`CSS Selector`提取目标数据
-- xpath_select：利用`XPath`提取目标数据
-- default：设置默认值
+- css_select：str, 利用`CSS Selector`提取目标数据
+- xpath_select：str, 利用`XPath`提取目标数据
 
 对于`TextField`，主要参数说明如下：
 - attr：目标标签属性
 - css_select：利用`CSS Selector`提取目标数据
 - xpath_select：利用`XPath`提取目标数据
-- default：设置默认值
 
 ### Usage
 

--- a/docs/en/topics/item.md
+++ b/docs/en/topics/item.md
@@ -38,6 +38,27 @@ for item in items:
 
 ```
 
+Sometimes we may come across such a condition.
+When crawling github issues, we will find that there are several tags to a issue.
+Define `TagItem` as a standalone item is not that beautiful.
+It's time to focus on the `many=True` argument.
+Fields with `many=True` will return a list.
+
+```python
+from ruia import Item, TextField
+
+class GithiubIssueItem(Item):
+    issue_id = TextField(css_select='issue_id_class')
+    title = TextField(css_select='issue_title_class')
+    tags = TextField(css_select='tag_class',many=True)
+    
+    
+item = GithiubIssueItem.get_item(html)
+assert isinstance(item.tags, list)
+```
+
+`AttrField` also has the argument `many`.
+
 ### How It Works?
 
 Inner, `item` class will change different kinds of inputs into `etree._Element` obejct, and then extract data.

--- a/docs/en/topics/selector.md
+++ b/docs/en/topics/selector.md
@@ -9,16 +9,19 @@ In detail, they are implemented by the following two classes:
 
 ### Core arguments
 
-Arguments of `AttrField` and `TextField`:
+Arguments of all `Field` classes:
+- default: default value if no HTML tag founded.
+- many: bool, the return value will be a list.
 
+
+Arguments of `TextField`:
 - css_select: locate the HTML tag by css selector.
 - xpath_select: locate the HTML tag by xpath selector.
-- default: default value if no HTML tag founded.
-
-对于`TextField`，主要参数说明如下：
 
 Arguments of `AttrField`:
 - attr: the target attribute name of HTML tag.
+- css_select: locate the HTML tag by css selector.
+- xpath_select: locate the HTML tag by xpath selector.
 
 ### Usage
 

--- a/ruia/field.py
+++ b/ruia/field.py
@@ -40,7 +40,6 @@ class _LxmlElementField(BaseField):
 
     def extract_value(self, html, is_source=False):
         elements = self._get_elements(html)
-        print(self.css_select, elements)
         if is_source:
             return elements if self.many else elements[0]
         results = [self._parse_element(element) for element in elements]

--- a/ruia/field.py
+++ b/ruia/field.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from lxml import etree
+from copy import deepcopy
 
 
 class BaseField(object):
@@ -39,6 +40,7 @@ class _LxmlElementField(BaseField):
 
     def extract_value(self, html, is_source=False):
         elements = self._get_elements(html)
+        print(self.css_select, elements)
         if is_source:
             return elements if self.many else elements[0]
         results = [self._parse_element(element) for element in elements]

--- a/ruia/field.py
+++ b/ruia/field.py
@@ -44,7 +44,10 @@ class _LxmlElementField(BaseField):
         if is_source:
             return elements if self.many else elements[0]
         results = [self._parse_element(element) for element in elements]
-        return results if self.many else results[0]
+        if self.many:
+            return results
+        else:
+            return results[0] if results else ''
 
 
 class TextField(_LxmlElementField):

--- a/ruia/field.py
+++ b/ruia/field.py
@@ -3,6 +3,10 @@ from lxml import etree
 from copy import deepcopy
 
 
+class NothingMatchedError(Exception):
+    pass
+
+
 class BaseField(object):
     """
     BaseField class
@@ -46,7 +50,13 @@ class _LxmlElementField(BaseField):
         if self.many:
             return results
         else:
-            return results[0] if results else ''
+            if len(results) >= 1:
+                return results[0]
+            else:
+                if self.default:
+                    return self.default
+                else:
+                    raise NothingMatchedError('Nothing matched, and default is not defined.')
 
 
 class TextField(_LxmlElementField):

--- a/ruia/item.py
+++ b/ruia/item.py
@@ -56,6 +56,7 @@ class Item(metaclass=ItemMeta):
             etree_result = html_etree
         items_field = getattr(cls, '__fields', {}).get('target_item', None)
         if items_field:
+            items_field.many = True
             items = items_field.extract_value(etree_result, is_source=True)
             if items:
                 tasks = [cls._parse_html(etree_result=i) for i in items]

--- a/test.py
+++ b/test.py
@@ -1,0 +1,11 @@
+import asyncio
+from ruia import Item, TextField, AttrField
+
+
+class GithiubIssueItem(Item):
+    title = TextField(css_select='title')
+    tags = AttrField(css_select='a.IssueLabel', attr='data-name', many=True)
+
+
+item = asyncio.run(GithiubIssueItem.get_item(url='https://github.com/pypa/pip/issues/72'))
+assert isinstance(item.tags, list)

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -5,6 +5,7 @@ import pytest
 from lxml import etree
 
 from ruia import AttrField, TextField
+from ruia.field import NothingMatchedError
 
 HTML = """
 <html>
@@ -65,14 +66,20 @@ def test_attr_field_many():
 
 def test_text_field_not_exist():
     field = TextField(css_select="nothing matched")
-    value = field.extract_value(html)
-    assert value == ''
+    try:
+        value = field.extract_value(html)
+        raise AssertionError
+    except NothingMatchedError:
+        pass
 
 
 def test_attr_field_not_exist():
     field = TextField(css_select="nothing matched")
-    value = field.extract_value(html)
-    assert value == ''
+    try:
+        value = field.extract_value(html)
+        raise AssertionError
+    except NothingMatchedError:
+        pass
 
 
 def test_text_field_many_even_there_is_only_one_in_html():
@@ -85,3 +92,29 @@ def test_attr_field_many_even_there_is_only_one_in_html():
     field = AttrField(css_select="div.brand a", attr="href", many=True)
     value = field.extract_value(html)
     assert value[0] == 'https://github.com'
+
+
+def test_text_field_with_default():
+    field = TextField(css_select="div.brand b", default='nothing')
+    value = field.extract_value(html)
+    assert value == 'nothing'
+
+
+def test_attr_field_with_default():
+    field = AttrField(css_select="div.brand b", attr='href', default='nothing')
+    value = field.extract_value(html)
+    assert value == 'nothing'
+
+
+def test_text_field_with_default_and_many():
+    field = TextField(css_select="div.brand b", default="nothing", many=True)
+    values = field.extract_value(html)
+    assert isinstance(values, list)
+    assert len(values) == 0
+
+
+def test_attr_field_with_default_and_many():
+    field = AttrField(css_select="div.brand b", attr="href", default="nothing", many=True)
+    values = field.extract_value(html)
+    assert isinstance(values, list)
+    assert len(values) == 0

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -12,8 +12,19 @@ HTML = """
         <title>ruia</title>
     </head>
     <body>¬
+    <div class="brand">
+        <h1><a href="https://github.com">Github</a></h1>
+    </div>
         <p>
-            <a class="test_link" href="https://github.com/howie6879/ruia">hello github.</a>
+            <a class="test_link" href="https://github.com/howie6879/ruia1">hello1 github.</a>
+        </p>        <p>
+            <a class="test_link" href="https://github.com/howie6879/ruia2">hello2 github.</a>
+        </p>        <p>
+            <a class="test_link" href="https://github.com/howie6879/ruia3">hello3 github.</a>
+        </p>        <p>
+            <a class="test_link" href="https://github.com/howie6879/ruia4">hello4 github.</a>
+        </p>        <p>
+            <a class="test_link" href="https://github.com/howie6879/ruia5">hello5 github.</a>
         </p>
     </body>
 </html>
@@ -35,6 +46,42 @@ def test_xpath_select():
 
 
 def test_attr_field():
-    attr_field = AttrField(css_select="p a.test_link", attr='href')
+    attr_field = AttrField(css_select="div.brand a", attr='href')
     value = attr_field.extract_value(html)
-    assert value == "https://github.com/howie6879/ruia"
+    assert value == "https://github.com"
+
+
+def test_text_field_many():
+    field = TextField(css_select="a.test_link", many=True)
+    values = field.extract_value(html)
+    assert values[2] == 'hello3 github.'
+
+
+def test_attr_field_many():
+    field = AttrField(css_select="a.test_link", attr="href", many=True)
+    values = field.extract_value(html)
+    assert values[3] == "https://github.com/howie6879/ruia4"
+
+
+def test_text_field_not_exist():
+    field = TextField(css_select="nothing matched")
+    value = field.extract_value(html)
+    assert value == ''
+
+
+def test_attr_field_not_exist():
+    field = TextField(css_select="nothing matched")
+    value = field.extract_value(html)
+    assert value == ''
+
+
+def test_text_field_many_even_there_is_only_one_in_html():
+    field = TextField(css_select="div.brand a", many=True)
+    value = field.extract_value(html)
+    assert value[0] == 'Github'
+
+
+def test_attr_field_many_even_there_is_only_one_in_html():
+    field = AttrField(css_select="div.brand a", attr="href", many=True)
+    value = field.extract_value(html)
+    assert value[0] == 'https://github.com'


### PR DESCRIPTION
I wrote a totally new model `field.py`.
it is **not backward-compatible**.

```
class AlbumItem(ruia.Item):
    title = TextField(css_select='title')
    tags = TextField(css_select='.label a', many=True)
    picture_urls = AttrField(css_select='.img img', attr='data-original', many=True)
```