### PR TITLE
Add re_flags to pass thru flags keyword to re.compile

### DIFF
--- a/ruia/field.py
+++ b/ruia/field.py
@@ -123,10 +123,10 @@ class RegexField(BaseField):
     RegexField uses standard library `re` inner, that is to say it has a better performance than _LxmlElementField.
     """
 
-    def __init__(self, re_select: str, default='', many: bool = False):
+    def __init__(self, re_select: str, re_flags=0, default='', many: bool = False):
         super(RegexField, self).__init__(default=default, many=many)
         self._re_select = re_select
-        self._re_object = re.compile(self._re_select)
+        self._re_object = re.compile(self._re_select, flags=re_flags)
 
     def _parse_match(self, match):
         """

--- a/ruia/request.py
+++ b/ruia/request.py
@@ -116,7 +116,7 @@ class Request(object):
             if response.ok:
                 return response
             else:
-                return await self._retry(error_msg='request url failed!')
+                return await self._retry(error_msg=f'request url failed with status {response.status}!')
         except asyncio.TimeoutError:
             return await self._retry(error_msg='timeout')
         except Exception as e:


### PR DESCRIPTION
This makes it possible to pass re.IGNORECASE for case-insensitive search