### PR TITLE
fix Chinese character gash problem in RegexField.extract

### DIFF
--- a/ruia/field.py
+++ b/ruia/field.py
@@ -163,7 +163,8 @@ class RegexField(BaseField):
 
     def extract(self, html: Union[str, etree._Element]):
         if isinstance(html, etree._Element):
-            html = etree.tostring(html).decode(encoding="utf-8")
+            # html = etree.tostring(html).decode(encoding="utf-8")
+            html = etree.tostring(html, encoding='utf-8', pretty_print=True, method='html').decode()
         if self.many:
             matches = self._re_object.finditer(html)
             return [self._parse_match(match) for match in matches]


### PR DESCRIPTION
#109 简单地处理了一下中文乱码，不知道会不会引发其他兼容性问题。

使用修正后的代码简单地测试了豆瓣网（中文）和[环球时报英文版](http://www.globaltimes.cn/)，正则表达式都能正常工作